### PR TITLE
Removed "wadas" from the conftest, to fix import issues on running tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,6 +1,6 @@
-import os
+import pathlib
 import sys
 
-# Add the wadas directory to the sys.path in order to be able to import the modules
-__this_dir__ = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.join(__this_dir__, "..", "wadas"))
+# Add the wadas directory to the sys.path in order to be able to import the modules.
+__this_dir = pathlib.Path(__file__).absolute().parent
+sys.path.append(str(__this_dir.parent))


### PR DESCRIPTION
Running tests with pytest failed because they were not able to import the modules from the wadas package.

Removing "wadas" from the path which is added to sys.path fixed this issue.