### PR TITLE
Force Qt style when running on windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 """Main of WADAS application."""
 
+import platform
 import sys
 
 from PySide6.QtWidgets import QApplication
@@ -11,6 +12,10 @@ def main():
     """Main function to lunch mainwindow."""
 
     app = QApplication(sys.argv)
+    system = platform.system()
+    if system == "Windows":
+        # Force style to avoid Win 11 issue with disabled icons not grayed out.
+        app.setStyle("fusion")
     window = MainWindow()
     window.show()
     sys.exit(app.exec())

--- a/wadas/conda_env_setup.yml
+++ b/wadas/conda_env_setup.yml
@@ -21,6 +21,6 @@ dependencies:
   - pip:
       - cv2-enumerate-cameras==1.1.15
       - intel-npu-acceleration-library==1.4.0
-      - pyside6==6.8.0
+      - pyside6==6.8.0.2
       - PytorchWildlife==1.0.2.16
       - pytest==8.3.3


### PR DESCRIPTION
Fix for Win 11 where disabled icons were not shown grayed out