### PR TITLE
Refactor of email configuration form to allow configuration of custom username

### DIFF
--- a/wadas/domain/email_notifier.py
+++ b/wadas/domain/email_notifier.py
@@ -36,13 +36,16 @@ logger = logging.getLogger(__name__)
 class EmailNotifier(Notifier):
     """Email Notifier Class"""
 
-    def __init__(self, sender_email, smtp_hostname, smtp_port, recipients_email, enabled=True):
+    def __init__(
+        self, sender_email, smtp_hostname, smtp_port, recipients_email, enabled=True, username=""
+    ):
         super().__init__(enabled)
         self.type = Notifier.NotifierTypes.EMAIL
         self.sender_email = sender_email
         self.smtp_hostname = smtp_hostname
         self.smtp_port = smtp_port
         self.recipients_email = recipients_email
+        self.username = username if username else sender_email
 
     def send_email(self, detection_event):
         """Method to build email and send it."""
@@ -100,7 +103,7 @@ class EmailNotifier(Notifier):
             context=context,
         ) as smtp_server:
             # Login to the SMTP server
-            smtp_server.login(self.sender_email, credentials.password)
+            smtp_server.login(self.username, credentials.password)
             # Send the email to all recipients.
             for recipient in self.recipients_email:
                 smtp_server.sendmail(self.sender_email, recipient, message.as_string())

--- a/wadas/ui/qt/configure_email.ui
+++ b/wadas/ui/qt/configure_email.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>522</width>
-    <height>337</height>
+    <height>397</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -35,11 +35,32 @@
          <x>10</x>
          <y>10</y>
          <width>461</width>
-         <height>196</height>
+         <height>254</height>
         </rect>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="3" column="4">
+        <item row="4" column="3" colspan="2">
+         <widget class="QLineEdit" name="lineEdit_password">
+          <property name="echoMode">
+           <enum>QLineEdit::EchoMode::Password</enum>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Sender email</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="3" colspan="2">
+         <widget class="QPushButton" name="pushButton_testEmail">
+          <property name="text">
+           <string>Test email</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="4">
          <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Orientation::Horizontal</enum>
@@ -52,61 +73,50 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="1">
-         <widget class="QLabel" name="label_4">
-          <property name="text">
-           <string>Port</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3" colspan="2">
-         <widget class="QLineEdit" name="lineEdit_password">
-          <property name="echoMode">
-           <enum>QLineEdit::EchoMode::Password</enum>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>password</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Sender email</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="3" colspan="2">
-         <widget class="QPushButton" name="pushButton_testEmail">
-          <property name="text">
-           <string>Test email</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="3" colspan="2">
+        <item row="5" column="3" colspan="2">
          <widget class="QLineEdit" name="lineEdit_smtpServer"/>
         </item>
-        <item row="0" column="3" colspan="2">
-         <widget class="QLineEdit" name="lineEdit_senderEmail"/>
-        </item>
-        <item row="3" column="3">
-         <widget class="QLineEdit" name="lineEdit_port"/>
-        </item>
-        <item row="2" column="1">
+        <item row="5" column="1">
          <widget class="QLabel" name="label_3">
           <property name="text">
            <string>SMTP server</string>
           </property>
          </widget>
         </item>
-        <item row="5" column="3" colspan="2">
+        <item row="6" column="1">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Port</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="3" colspan="2">
          <widget class="QPlainTextEdit" name="plainTextEdit_test_log">
           <property name="readOnly">
            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Password</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3" colspan="2">
+         <widget class="QLineEdit" name="lineEdit_senderEmail"/>
+        </item>
+        <item row="6" column="3">
+         <widget class="QLineEdit" name="lineEdit_port"/>
+        </item>
+        <item row="3" column="4">
+         <widget class="QLineEdit" name="lineEdit_username"/>
+        </item>
+        <item row="3" column="1" colspan="3">
+         <widget class="QCheckBox" name="checkBox_username">
+          <property name="text">
+           <string>Username (if different from sender email):</string>
           </property>
          </widget>
         </item>

--- a/wadas/ui/qt/ui_configure_email.py
+++ b/wadas/ui/qt/ui_configure_email.py
@@ -24,7 +24,7 @@ class Ui_DialogConfigureEmail(object):
     def setupUi(self, DialogConfigureEmail):
         if not DialogConfigureEmail.objectName():
             DialogConfigureEmail.setObjectName(u"DialogConfigureEmail")
-        DialogConfigureEmail.resize(522, 337)
+        DialogConfigureEmail.resize(522, 397)
         sizePolicy = QSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -38,29 +38,15 @@ class Ui_DialogConfigureEmail(object):
         self.tab_3.setObjectName(u"tab_3")
         self.gridLayoutWidget = QWidget(self.tab_3)
         self.gridLayoutWidget.setObjectName(u"gridLayoutWidget")
-        self.gridLayoutWidget.setGeometry(QRect(10, 10, 461, 196))
+        self.gridLayoutWidget.setGeometry(QRect(10, 10, 461, 254))
         self.gridLayout = QGridLayout(self.gridLayoutWidget)
         self.gridLayout.setObjectName(u"gridLayout")
         self.gridLayout.setContentsMargins(0, 0, 0, 0)
-        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
-
-        self.gridLayout.addItem(self.horizontalSpacer, 3, 4, 1, 1)
-
-        self.label_4 = QLabel(self.gridLayoutWidget)
-        self.label_4.setObjectName(u"label_4")
-
-        self.gridLayout.addWidget(self.label_4, 3, 1, 1, 1)
-
         self.lineEdit_password = QLineEdit(self.gridLayoutWidget)
         self.lineEdit_password.setObjectName(u"lineEdit_password")
         self.lineEdit_password.setEchoMode(QLineEdit.EchoMode.Password)
 
-        self.gridLayout.addWidget(self.lineEdit_password, 1, 3, 1, 2)
-
-        self.label_2 = QLabel(self.gridLayoutWidget)
-        self.label_2.setObjectName(u"label_2")
-
-        self.gridLayout.addWidget(self.label_2, 1, 1, 1, 1)
+        self.gridLayout.addWidget(self.lineEdit_password, 4, 3, 1, 2)
 
         self.label = QLabel(self.gridLayoutWidget)
         self.label.setObjectName(u"label")
@@ -70,12 +56,37 @@ class Ui_DialogConfigureEmail(object):
         self.pushButton_testEmail = QPushButton(self.gridLayoutWidget)
         self.pushButton_testEmail.setObjectName(u"pushButton_testEmail")
 
-        self.gridLayout.addWidget(self.pushButton_testEmail, 4, 3, 1, 2)
+        self.gridLayout.addWidget(self.pushButton_testEmail, 7, 3, 1, 2)
+
+        self.horizontalSpacer = QSpacerItem(40, 20, QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Minimum)
+
+        self.gridLayout.addItem(self.horizontalSpacer, 6, 4, 1, 1)
 
         self.lineEdit_smtpServer = QLineEdit(self.gridLayoutWidget)
         self.lineEdit_smtpServer.setObjectName(u"lineEdit_smtpServer")
 
-        self.gridLayout.addWidget(self.lineEdit_smtpServer, 2, 3, 1, 2)
+        self.gridLayout.addWidget(self.lineEdit_smtpServer, 5, 3, 1, 2)
+
+        self.label_3 = QLabel(self.gridLayoutWidget)
+        self.label_3.setObjectName(u"label_3")
+
+        self.gridLayout.addWidget(self.label_3, 5, 1, 1, 1)
+
+        self.label_4 = QLabel(self.gridLayoutWidget)
+        self.label_4.setObjectName(u"label_4")
+
+        self.gridLayout.addWidget(self.label_4, 6, 1, 1, 1)
+
+        self.plainTextEdit_test_log = QPlainTextEdit(self.gridLayoutWidget)
+        self.plainTextEdit_test_log.setObjectName(u"plainTextEdit_test_log")
+        self.plainTextEdit_test_log.setReadOnly(True)
+
+        self.gridLayout.addWidget(self.plainTextEdit_test_log, 8, 3, 1, 2)
+
+        self.label_2 = QLabel(self.gridLayoutWidget)
+        self.label_2.setObjectName(u"label_2")
+
+        self.gridLayout.addWidget(self.label_2, 4, 1, 1, 1)
 
         self.lineEdit_senderEmail = QLineEdit(self.gridLayoutWidget)
         self.lineEdit_senderEmail.setObjectName(u"lineEdit_senderEmail")
@@ -85,18 +96,17 @@ class Ui_DialogConfigureEmail(object):
         self.lineEdit_port = QLineEdit(self.gridLayoutWidget)
         self.lineEdit_port.setObjectName(u"lineEdit_port")
 
-        self.gridLayout.addWidget(self.lineEdit_port, 3, 3, 1, 1)
+        self.gridLayout.addWidget(self.lineEdit_port, 6, 3, 1, 1)
 
-        self.label_3 = QLabel(self.gridLayoutWidget)
-        self.label_3.setObjectName(u"label_3")
+        self.lineEdit_username = QLineEdit(self.gridLayoutWidget)
+        self.lineEdit_username.setObjectName(u"lineEdit_username")
 
-        self.gridLayout.addWidget(self.label_3, 2, 1, 1, 1)
+        self.gridLayout.addWidget(self.lineEdit_username, 3, 4, 1, 1)
 
-        self.plainTextEdit_test_log = QPlainTextEdit(self.gridLayoutWidget)
-        self.plainTextEdit_test_log.setObjectName(u"plainTextEdit_test_log")
-        self.plainTextEdit_test_log.setReadOnly(True)
+        self.checkBox_username = QCheckBox(self.gridLayoutWidget)
+        self.checkBox_username.setObjectName(u"checkBox_username")
 
-        self.gridLayout.addWidget(self.plainTextEdit_test_log, 5, 3, 1, 2)
+        self.gridLayout.addWidget(self.checkBox_username, 3, 1, 1, 3)
 
         self.tabWidget.addTab(self.tab_3, "")
         self.tab_4 = QWidget()
@@ -148,11 +158,12 @@ class Ui_DialogConfigureEmail(object):
 
     def retranslateUi(self, DialogConfigureEmail):
         DialogConfigureEmail.setWindowTitle(QCoreApplication.translate("DialogConfigureEmail", u"Configure Email notifications", None))
-        self.label_4.setText(QCoreApplication.translate("DialogConfigureEmail", u"Port", None))
-        self.label_2.setText(QCoreApplication.translate("DialogConfigureEmail", u"password", None))
         self.label.setText(QCoreApplication.translate("DialogConfigureEmail", u"Sender email", None))
         self.pushButton_testEmail.setText(QCoreApplication.translate("DialogConfigureEmail", u"Test email", None))
         self.label_3.setText(QCoreApplication.translate("DialogConfigureEmail", u"SMTP server", None))
+        self.label_4.setText(QCoreApplication.translate("DialogConfigureEmail", u"Port", None))
+        self.label_2.setText(QCoreApplication.translate("DialogConfigureEmail", u"Password", None))
+        self.checkBox_username.setText(QCoreApplication.translate("DialogConfigureEmail", u"Username (if different from sender email):", None))
         self.tabWidget.setTabText(self.tabWidget.indexOf(self.tab_3), QCoreApplication.translate("DialogConfigureEmail", u"Sender", None))
         self.label_5.setText(QCoreApplication.translate("DialogConfigureEmail", u"Insert recipients email address(es) separated by comma and space. ", None))
         self.label_6.setText(QCoreApplication.translate("DialogConfigureEmail", u"Example: email1@domail.com, email2@domail.com, email3@domail.com", None))


### PR DESCRIPTION
As some email configuration might require an username different from sender email, a custom username field has been introduced.